### PR TITLE
:arrow_up: Upgrade CI to Go 1.19

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,28 +2,27 @@ name: Go
 
 on:
   push:
-    branches: [ dev ]
+    branches: [dev]
   pull_request:
-    branches: [ dev ]
+    branches: [dev]
 
 jobs:
-
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Set up Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: 1.17
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.19
 
-    - name: Build
-      run: make 
-    
-    - name: Upload a Build Artifact
-      uses: actions/upload-artifact@v2.3.1
-      with:
-        # Artifact name
-        name: Wiki CLI
-        path: ./build
+      - name: Build
+        run: make
+
+      - name: Upload a Build Artifact
+        uses: actions/upload-artifact@v2.3.1
+        with:
+          # Artifact name
+          name: Wiki CLI
+          path: ./build

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/betapictoris/wiki
 
-go 1.18
+go 1.19
 
 require (
 	github.com/JohannesKaufmann/html-to-markdown v1.3.3


### PR DESCRIPTION
Build fails on 1.17